### PR TITLE
CMake fetch picoquic 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0003 NEW)
-project(quicrq C CXX)
+project(picoquic_ns C CXX)
 find_package (Threads REQUIRED)
 FIND_PACKAGE(PkgConfig REQUIRED)
 
@@ -13,6 +13,20 @@ if(DISABLE_DEBUG_PRINTF)
 endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+OPTION(PICOQUIC_NS_FETCH_PICOQUIC "Fetch PicoQUIC during configuration" OFF)
+if(PICOQUIC_NS_FETCH_PICOQUIC)
+    # fetch picoquic from GitHub
+    include(FetchContent)
+    FetchContent_Declare(
+            picoquic
+            GIT_REPOSITORY  https://github.com/private-octopus/picoquic.git
+            GIT_TAG         master
+    )
+    set(PICOQUIC_FETCH_PTLS ON)
+    set(picoquic_BUILD_TESTS ON)
+    FetchContent_MakeAvailable(picoquic)
+endif ()
 
 find_package(Picoquic REQUIRED)
 message(STATUS "Picoquic/include: ${Picoquic_INCLUDE_DIRS}" )
@@ -43,14 +57,16 @@ target_link_libraries(pico_sim
     ${CMAKE_THREAD_LIBS_INIT}
 )
 
-# get all project files for formatting
-file(GLOB_RECURSE CLANG_FORMAT_SOURCE_FILES *.c *.h)
+if (NOT PICOQUIC_NS_FETCH_PICOQUIC)
+    # get all project files for formatting
+    file(GLOB_RECURSE CLANG_FORMAT_SOURCE_FILES *.c *.h)
 
-# Adds clangformat as target that formats all source files
-add_custom_target(
-    clangformat
-    COMMAND clang-format
-    -style=Webkit
-    -i
-    ${CLANG_FORMAT_SOURCE_FILES}
-)
+    # Adds clangformat as target that formats all source files
+    add_custom_target(
+        clangformat
+        COMMAND clang-format
+        -style=Webkit
+        -i
+        ${CLANG_FORMAT_SOURCE_FILES}
+    )
+endif (NOT PICOQUIC_NS_FETCH_PICOQUIC)

--- a/cmake/FindPicoquic.cmake
+++ b/cmake/FindPicoquic.cmake
@@ -1,58 +1,68 @@
 # - Try to find Picoquic
 
+if (PICOQUIC_NS_FETCH_PICOQUIC)
+    set(Picoquic_INCLUDE_DIR ${picoquic_SOURCE_DIR}/picoquic)
+    set(Picoquic_TEST_DIR ${picoquic_SOURCE_DIR}/picoquictest)
+    set(Picoquic_LOG_DIR ${picoquic_SOURCE_DIR}/loglib)
 
-find_path(Picoquic_INCLUDE_DIR
-    NAMES picoquic.h
-    HINTS ${CMAKE_SOURCE_DIR}/../picoquic/picoquic
-          ${CMAKE_BINARY_DIR}/../picoquic/picoquic
-          ../picoquic/picoquic/ )
+    set(Picoquic_CORE_LIBRARY picoquic-core)
+    set(Picoquic_LOG_LIBRARY picoquic-log)
+    set(Picoquic_TEST_LIBRARY picoquic-test)
+    set(Picoquic_HTTP_LIBRARY picohttp-core)
+else(PICOQUIC_NS_FETCH_PICOQUIC)
+    find_path(Picoquic_INCLUDE_DIR
+        NAMES picoquic.h
+        HINTS ${CMAKE_SOURCE_DIR}/../picoquic/picoquic
+              ${CMAKE_BINARY_DIR}/../picoquic/picoquic
+              ../picoquic/picoquic/ )
 
-find_path(Picoquic_TEST_DIR
-    NAMES picoquic_ns.h
-    HINTS ${CMAKE_SOURCE_DIR}/../picoquic/picoquictest
-          ${CMAKE_BINARY_DIR}/../picoquic/picoquictest
-          ../picoquic/picoquictest/ )
+    find_path(Picoquic_TEST_DIR
+        NAMES picoquic_ns.h
+        HINTS ${CMAKE_SOURCE_DIR}/../picoquic/picoquictest
+              ${CMAKE_BINARY_DIR}/../picoquic/picoquictest
+              ../picoquic/picoquictest/ )
 
-find_path(Picoquic_LOG_DIR
-    NAMES autoqlog.h
-    HINTS ${CMAKE_SOURCE_DIR}/../picoquic/loglib
-          ${CMAKE_BINARY_DIR}/../picoquic/loglib
-          ../picotls/picoquic/ )
+    find_path(Picoquic_LOG_DIR
+        NAMES autoqlog.h
+        HINTS ${CMAKE_SOURCE_DIR}/../picoquic/loglib
+              ${CMAKE_BINARY_DIR}/../picoquic/loglib
+              ../picotls/picoquic/ )
 
-set(Picoquic_HINTS 
-    ${CMAKE_BINARY_DIR}/../picoquic
-    ${CMAKE_BINARY_DIR}/../picoquic/build 
-    ../picoquic
-    ../picoquic/build )
+    set(Picoquic_HINTS
+        ${CMAKE_BINARY_DIR}/../picoquic
+        ${CMAKE_BINARY_DIR}/../picoquic/build
+        ../picoquic
+        ../picoquic/build)
 
-find_library(Picoquic_CORE_LIBRARY picoquic-core HINTS ${Picoquic_HINTS})
-find_library(Picoquic_LOG_LIBRARY picoquic-log HINTS ${Picoquic_HINTS})
-find_library(Picoquic_TEST_LIBRARY picoquic-test HINTS ${Picoquic_HINTS})
-find_library(Picoquic_HTTP_LIBRARY picohttp-core HINTS ${Picoquic_HINTS})
+    find_library(Picoquic_CORE_LIBRARY picoquic-core HINTS ${Picoquic_HINTS})
+    find_library(Picoquic_LOG_LIBRARY picoquic-log HINTS ${Picoquic_HINTS})
+    find_library(Picoquic_TEST_LIBRARY picoquic-test HINTS ${Picoquic_HINTS})
+    find_library(Picoquic_HTTP_LIBRARY picohttp-core HINTS ${Picoquic_HINTS})
+endif(PICOQUIC_NS_FETCH_PICOQUIC)
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set Picoquic_FOUND to TRUE
 # if all listed variables are TRUE
 find_package_handle_standard_args(Picoquic REQUIRED_VARS
-    Picoquic_CORE_LIBRARY
-    Picoquic_TEST_LIBRARY
-    Picoquic_LOG_LIBRARY
-    Picoquic_HTTP_LIBRARY
-    Picoquic_INCLUDE_DIR
-    Picoquic_LOG_DIR
-    Picoquic_TEST_DIR )
+        Picoquic_CORE_LIBRARY
+        Picoquic_TEST_LIBRARY
+        Picoquic_LOG_LIBRARY
+        Picoquic_HTTP_LIBRARY
+        Picoquic_INCLUDE_DIR
+        Picoquic_LOG_DIR
+        Picoquic_TEST_DIR )
 
 if(Picoquic_FOUND)
     set(Picoquic_LIBRARIES
-        ${Picoquic_TEST_LIBRARY} 
-        ${Picoquic_HTTP_LIBRARY}
-        ${Picoquic_LOG_LIBRARY} 
-        ${Picoquic_CORE_LIBRARY}
+            ${Picoquic_TEST_LIBRARY}
+            ${Picoquic_HTTP_LIBRARY}
+            ${Picoquic_LOG_LIBRARY}
+            ${Picoquic_CORE_LIBRARY}
     )
     set(Picoquic_INCLUDE_DIRS
-        ${Picoquic_INCLUDE_DIR}
-        ${Picoquic_TEST_DIR}
-        ${Picoquic_BINLOG_DIR})
+            ${Picoquic_INCLUDE_DIR}
+            ${Picoquic_TEST_DIR}
+            ${Picoquic_LOG_DIR})
 endif()
 
 mark_as_advanced(Picoquic_LIBRARIES Picoquic_INCLUDE_DIRS)


### PR DESCRIPTION
Currently picoquic_ns searchs for Picoquic in the parent folder of the project directory. (`../picoquic`) 
These changes enable us to clone and compile picoquic-ns, Picoquic and all of its dependencies in a single command.

`cmake -DPICOQUIC_NS_FETCH_PICOQUIC=Y .`


