### PR TITLE
Support media simulations

### DIFF
--- a/pico_sim_vs/pico_sim_vs.vcxproj.user
+++ b/pico_sim_vs/pico_sim_vs.vcxproj.user
@@ -11,7 +11,7 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>-S $(SolutionDir)\..\..\picoquic $(SolutionDir)..\sim_specs\dcubic_vs_cubic.txt</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-S $(SolutionDir)\..\..\picoquic $(SolutionDir)..\sim_specs\bbr_media.txt</LocalDebuggerCommandArguments>
     <LocalDebuggerWorkingDirectory>$(OutDir)</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>

--- a/sim_specs/bbr_media.txt
+++ b/sim_specs/bbr_media.txt
@@ -1,0 +1,15 @@
+main_cc_algo: bbr
+main_start_time: 0
+main_scenario_text: =a1:d50:p2:S:n250:80;=vlow:s30:p4:S:n150:3750:G30:I37500;=vmid:s30:p6:S:n150:6250:G30:I62500:D250000;
+nb_connections: 1
+main_target_time: 10000000
+data_rate_in_gbps: 0.1
+latency: 15000
+queue_delay_max: 100000
+icid: ed1abb00
+qlog_dir: cclog
+qperf_log: bbr_media_qperflog.csv
+media_stats_start: 200000
+media_latency_average: 32000
+media_latency_max: 112000
+media_excluded: vhigh, vmid, vlast

--- a/sim_specs/cubic_media.txt
+++ b/sim_specs/cubic_media.txt
@@ -1,0 +1,15 @@
+main_cc_algo: bbr
+main_start_time: 0
+main_scenario_text: =a1:d50:p2:S:n250:80;=vlow:s30:p4:S:n150:3750:G30:I37500;=vmid:s30:p6:S:n150:6250:G30:I62500:D250000;
+nb_connections: 1
+main_target_time: 10000000
+data_rate_in_gbps: 0.1
+latency: 15000
+queue_delay_max: 100000
+icid: ed1abb00
+qlog_dir: cclog
+qperf_log: cubic_media_qperflog.csv
+media_stats_start: 200000
+media_latency_average: 31000
+media_latency_max: 44000
+media_excluded: vhigh, vmid, vlast

--- a/sim_specs/cubic_media.txt
+++ b/sim_specs/cubic_media.txt
@@ -1,4 +1,4 @@
-main_cc_algo: bbr
+main_cc_algo: cubic
 main_start_time: 0
 main_scenario_text: =a1:d50:p2:S:n250:80;=vlow:s30:p4:S:n150:3750:G30:I37500;=vmid:s30:p6:S:n150:6250:G30:I62500:D250000;
 nb_connections: 1

--- a/src/pico_sim.c
+++ b/src/pico_sim.c
@@ -304,6 +304,8 @@ void release_spec_data(picoquic_ns_spec_t* spec)
     release_text(&spec->main_scenario_text);
     release_text(&spec->background_scenario_text);
     release_text(&spec->qlog_dir);
+    release_text(&spec->qperf_log);
+    release_text(&spec->media_excluded);
 }
 
 int parse_u64(uint64_t* x, char const* val)

--- a/src/pico_sim.c
+++ b/src/pico_sim.c
@@ -80,10 +80,10 @@ int main(int argc, char** argv)
     else
     {
         if (parse_spec_file(&spec, F) != 0) {
-            fprintf(stderr, "Error when processing file <%s>\n", spec_file_name);
+            printf("Error when processing file <%s>\n", spec_file_name);
         }
         else {
-            ret = picoquic_ns(&spec);
+            ret = picoquic_ns(&spec, stderr);
             printf("picoquic_ns (%s) returns %d\n", spec_file_name, ret);
         }
         F = picoquic_file_close(F);
@@ -110,6 +110,11 @@ typedef enum {
     e_l4s_max,
     e_icid,
     e_qlog_dir,
+    e_qperf_log,
+    e_media_stats_start,
+    e_media_excluded,
+    e_media_latency_average,
+    e_media_latency_max,
     e_error
 } spec_param_enum;
 
@@ -136,7 +141,12 @@ spec_param_t params[] = {
     { e_queue_delay_max, "queue_delay_max", 15 },
     { e_l4s_max, "l4s_max", 7 },
     { e_icid, "icid", 4 },
-    { e_qlog_dir, "qlog_dir", 8 }
+    { e_qlog_dir, "qlog_dir", 8 },
+    { e_qperf_log, "qperf_log", 9},
+    { e_media_stats_start, "media_stats_start", 17},
+    { e_media_excluded, "media_excluded", 14},
+    { e_media_latency_average, "media_latency_average", 21},
+    { e_media_latency_max, "media_latency_max", 17},
 };
 
 const size_t nb_params = sizeof(params) / sizeof(spec_param_t);
@@ -262,9 +272,27 @@ int parse_param(picoquic_ns_spec_t* spec, spec_param_enum p_e, char const* line)
         case e_qlog_dir:
             ret = parse_file_name(&spec->qlog_dir, line);
             break;
-        default:
-            fprintf(stderr, "Incorrect specification line: %s\n", line);
+        case e_qperf_log:
+            ret = parse_file_name(&spec->qperf_log, line);
             break;
+        case e_media_stats_start:
+            ret = parse_u64(&spec->media_stats_start, line);
+            break;
+        case e_media_excluded:
+            ret = parse_text(&spec->media_excluded, line);
+            break;
+        case e_media_latency_average:
+            ret = parse_u64(&spec->media_latency_average, line);
+            break;
+        case e_media_latency_max:
+            ret = parse_u64(&spec->media_latency_max, line);
+            break;
+        default:
+            ret = -1;
+            break;
+        }
+        if (ret != 0) {
+            fprintf(stderr, "Error parsing param %d: %s\n", p_e, line);
         }
     }
 


### PR DESCRIPTION
The QPERF protocol has been extended in picoquic to allow simulation of "media streams". The simulation mimics the media model used in [Media Over QUIC](https://datatracker.ietf.org/wg/moq/about/), in which media streams materialize as either series of datagrams each containing a media frame, or series of unidirectional streams each containing a group of frames, typically an I-Frame followed by a series of P-Frames. The simulation can specify a priority for each of those media streams, and a "drop delay" instructing the code to reset a Quic stream if transmission of frames falls to far being time.

the support for QPERF media stream includes:

* specifying an optional "qperf_log" CSV file that will contain a separate row for each media frame, tracking expected departure time and actual receive time,
* checking whether the average and max delays of media frames are lower than specified values.

To support scenarios that include network disruptions, it is possible to specify the simulated time after which average and max delays are gathered. Not all streams have the same priority, so it is also possible to exclude from the checks some low priority streams.